### PR TITLE
Increase file size limits

### DIFF
--- a/cloudrun-malware-scanner/bootstrap.sh
+++ b/cloudrun-malware-scanner/bootstrap.sh
@@ -114,15 +114,15 @@ function updateClamConfigFile {
 # https://manpages.debian.org/bullseye/clamav-daemon/clamd.conf.5.en.html
 updateClamConfigFile /etc/clamav/clamd.conf << EOF
 # This option allows you to specify the upper limit for data size that will be transfered to remote daemon when scanning a single file.
-StreamMaxLength 521M
+StreamMaxLength 50000M
 
 # Sets the maximum amount of data to be scanned for each input file.
 # Archives and other containers are recursively extracted and scanned up to this value.
-MaxScanSize 512M
+MaxScanSize 50000M
 
 # Files larger than this limit won't be scanned.
 # Affects the input file itself as well as files contained inside it (when the input file is an archive, a document or some other kind of container).
-MaxFileSize 512M
+MaxFileSize 50000M
 
 # Nested archives are scanned recursively, e.g. if a Zip archive contains a RAR file, all files within it will also be scanned.
 # This options specifies how deeply the process should be continued.

--- a/cloudrun-malware-scanner/server.js
+++ b/cloudrun-malware-scanner/server.js
@@ -29,8 +29,8 @@ const PORT = process.env.PORT || 8080;
 const CLAMD_HOST = '127.0.0.1';
 const CLAMD_PORT = 3310;
 
-// 10 min timeout for scanning.
-const CLAMD_TIMEOUT = 600000;
+// 60 min timeout for scanning.
+const CLAMD_TIMEOUT = 3600000;
 
 // Note: MAX_FILE_SIZE limits the size of files which are sent to th
 // ClamAV Daemon.
@@ -41,7 +41,7 @@ const CLAMD_TIMEOUT = 600000;
 //
 // Note scanning a 500MiB file can take 5 minutes, so ensure timeout is
 // large enough.
-const MAX_FILE_SIZE = 500000000; // 500MiB
+const MAX_FILE_SIZE = 50000000000; // 50GB
 const CVD_MIRROR_BUCKET = process.env.CVD_MIRROR_BUCKET;
 
 // Create Clients.


### PR DESCRIPTION
Max archive size of 50GB and 1 hour timeout to run AV scan.