### PR TITLE
Read each file in .zip archive individually instead of entire archive at once

### DIFF
--- a/cloudrun-malware-scanner/package-lock.json
+++ b/cloudrun-malware-scanner/package-lock.json
@@ -20,7 +20,8 @@
         "express": "^4.18.2",
         "google-auth-library": "^8.7.0",
         "node-fetch": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "unzip-stream": "^0.3.1"
       },
       "devDependencies": {
         "eslint": "^8.29.0",
@@ -693,6 +694,18 @@
         "node": "*"
       }
     },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -747,6 +760,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/bunyan": {
       "version": "1.8.15",
@@ -803,6 +824,17 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -2614,7 +2646,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "optional": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -3509,6 +3540,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3572,6 +3611,15 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzip-stream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.1.tgz",
+      "integrity": "sha512-RzaGXLNt+CW+T41h1zl6pGz3EaeVhYlK+rdAap+7DxW5kqsqePO8kRtWPaCiVqdhZc86EctSPVYNix30YOMzmw==",
+      "dependencies": {
+        "binary": "^0.3.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "node_modules/uri-js": {
@@ -4243,6 +4291,15 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
       "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4296,6 +4353,11 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
+    },
     "bunyan": {
       "version": "1.8.15",
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
@@ -4333,6 +4395,14 @@
       "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "requires": {
         "lodash": "^4.17.15"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -5685,7 +5755,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "optional": true,
       "requires": {
         "minimist": "^1.2.6"
       }
@@ -6321,6 +6390,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6364,6 +6438,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "unzip-stream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.1.tgz",
+      "integrity": "sha512-RzaGXLNt+CW+T41h1zl6pGz3EaeVhYlK+rdAap+7DxW5kqsqePO8kRtWPaCiVqdhZc86EctSPVYNix30YOMzmw==",
+      "requires": {
+        "binary": "^0.3.0",
+        "mkdirp": "^0.5.1"
+      }
     },
     "uri-js": {
       "version": "4.4.1",

--- a/cloudrun-malware-scanner/package.json
+++ b/cloudrun-malware-scanner/package.json
@@ -23,7 +23,8 @@
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
     "node-fetch": "^3.3.0",
-    "process": "^0.11.10"
+    "process": "^0.11.10",
+    "unzip-stream": "^0.3.1"
   },
   "devDependencies": {
     "eslint": "^8.29.0",

--- a/cloudrun-malware-scanner/server.js
+++ b/cloudrun-malware-scanner/server.js
@@ -24,13 +24,11 @@ const metrics = require('./metrics.js');
 const util = require('node:util');
 const execFile = util.promisify(require('node:child_process').execFile);
 const {setTimeout} = require('timers/promises');
+const scanGcsZipFile = require('./zip.js');
 
 const PORT = process.env.PORT || 8080;
 const CLAMD_HOST = '127.0.0.1';
 const CLAMD_PORT = 3310;
-
-// 10 min timeout for scanning.
-const CLAMD_TIMEOUT = 600000;
 
 // Note: MAX_FILE_SIZE limits the size of files which are sent to th
 // ClamAV Daemon.
@@ -43,6 +41,9 @@ const CLAMD_TIMEOUT = 600000;
 // large enough.
 const MAX_FILE_SIZE = 100000000000; // 100 GB
 const CVD_MIRROR_BUCKET = process.env.CVD_MIRROR_BUCKET;
+
+// 5 min timeout for scanning per file.
+const CLAMD_TIMEOUT = 300000;
 
 // Create Clients.
 const app = express();
@@ -90,6 +91,7 @@ app.post('/', async (req, res) => {
  */
 async function handleGcsObject(req, res) {
   const file = req.body;
+  logger.info('Received request to scan file: %s', JSON.stringify(file));
   try {
     if (!file.name) {
       handleErrorResponse(res, 200, `file name not specified in ${file}`);
@@ -99,8 +101,15 @@ async function handleGcsObject(req, res) {
       handleErrorResponse(res, 200, `bucket name not specified in ${file}`);
       return;
     }
+    // file name must end in .zip
+    if (!file.name.endsWith('.zip')) {
+      handleErrorResponse(res, 200,
+          `file gs://${file.bucket}/${file.name} is not a .zip`,
+          file.bucket);
+      return;
+    }
     const fileSize = parseInt(file.size);
-    if ( fileSize > MAX_FILE_SIZE) {
+    if (fileSize > MAX_FILE_SIZE) {
       handleErrorResponse(
           res, 200,
           `file gs://${file.bucket}/${file.name} too large for scanning at ${
@@ -126,18 +135,17 @@ async function handleGcsObject(req, res) {
     logger.info(`Scan request for gs://${file.bucket}/${file.name}, (${
       fileSize} bytes) scanning with clam ${clamdVersion}`);
     const startTime = Date.now();
-    const readStream = await gcsFile.createReadStream();
-    let result;
-    try {
-      result = await scanner.scanStream(readStream, CLAMD_TIMEOUT);
-    } finally {
-      // Ensure stream is destroyed in all situations to prevent any
-      // resource leaks.
-      readStream.destroy();
-    }
+
+    // break up .zip archive by scanning each individual file separately to
+    // avoid the 4GB hard limit on clamd.
+    // const reader = new GcsFileRangeReader(gcsFile, GCS_FILE_READ_BUFFER_SIZE)
+    const rs = gcsFile.createReadStream();
+    const results = await scanGcsZipFile(
+        scanner, rs, fileSize, CLAMD_TIMEOUT);
+
     const scanDuration = Date.now() - startTime;
 
-    if (clamd.isCleanReply(result)) {
+    if (results.every((result) => clamd.isCleanReply(result.result))) {
       logger.info(`Scan status for gs://${file.bucket}/${file.name}: CLEAN (${
         fileSize} bytes in ${scanDuration} ms)`);
       metrics.writeScanClean('gs://${file.bucket}', fileSize,
@@ -146,17 +154,20 @@ async function handleGcsObject(req, res) {
       // Respond to API client.
       res.json({status: 'clean', clam_version: clamdVersion});
     } else {
-      logger.warn(`Scan status for gs://${file.bucket}/${
-        file.name}: INFECTED ${result} (${
-        fileSize} bytes in ${scanDuration} ms)`);
+      const infectedResult = results.find(
+          (result) => !clamd.isCleanReply(result.result));
+      logger.warn(`Scan status for gs://${file.bucket}/${file.name}/
+        ${infectedResult.fileName}: INFECTED ${infectedResult.result} 
+        (${fileSize} bytes in ${scanDuration} ms)`);
       metrics.writeScanInfected('gs://${file.bucket}', fileSize,
           scanDuration, clamdVersion);
 
       // Respond to API client.
       res.json({
-        message: result,
+        message: `infected file ${infectedResult.fileName} with result: 
+            ${infectedResult.result}`,
         status: 'infected',
-        result: result,
+        result: infectedResult.result,
         clam_version: clamdVersion,
       });
     }

--- a/cloudrun-malware-scanner/zip.js
+++ b/cloudrun-malware-scanner/zip.js
@@ -1,0 +1,35 @@
+const {logger} = require('./logger.js');
+const unzip = require('unzip-stream');
+
+/**
+ * @param {*} scanner
+ * @param {*} readstream
+ * @param {number} totalSize
+ * @param {number} timeoutPerFile
+ * @return {Promise<Array<string>>} collection of clamd results
+ */
+function scanGcsZipFile(scanner, readstream, totalSize, timeoutPerFile) {
+  const results = [];
+
+  return new Promise((resolve, reject) => {
+    // eslint-disable-next-line new-cap
+    readstream.pipe(unzip.Parse()).on('entry', async (entry) => {
+      if (entry.type === 'File') {
+        logger.info(`Scanning ${entry.path} with size ${entry.size}`);
+        const result = await scanner.scanStream(entry, timeoutPerFile);
+        results.push({result, fileName: entry.path});
+        logger.info(`Finished scanning ${entry.path} with result ${result}`);
+      } else {
+        entry.autodrain();
+      }
+    }).on('close', () => {
+      logger.info(`Finished scanning ${totalSize} bytes`);
+      resolve(results);
+    }).on('error', (err) => {
+      logger.error(`Error scanning zip file: ${err}`);
+      reject(err);
+    });
+  });
+}
+
+module.exports = scanGcsZipFile;


### PR DESCRIPTION
This is a workaround for clamd's hard 4GB per-file limit. Use `unzip-stream` to read zip file with streaming from GCS (see reader.js) and then stream each file inside the .zip archive to clamd.