### PR TITLE
Handle files larger than 4GB

### DIFF
--- a/cloudrun-malware-scanner/Dockerfile
+++ b/cloudrun-malware-scanner/Dockerfile
@@ -38,6 +38,7 @@ COPY config.json  /app
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 # Required. Bucket for clamav mirror bucket.
 ENV CVD_MIRROR_BUCKET ""
+ENV LARGE_FILE_CHUNK_SIZE ""
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -qqy && \
     apt-get install -qqy --no-install-recommends  \

--- a/cloudrun-malware-scanner/server.js
+++ b/cloudrun-malware-scanner/server.js
@@ -39,11 +39,11 @@ const CLAMD_PORT = 3310;
 //
 // Note scanning a 500MiB file can take 5 minutes, so ensure timeout is
 // large enough.
-const MAX_FILE_SIZE = 100000000000; // 100 GB
+const MAX_FILE_SIZE = 100 * 1024 * 1024 * 1024; // 100 GB
 const CVD_MIRROR_BUCKET = process.env.CVD_MIRROR_BUCKET;
 
 // 5 min timeout for scanning per file.
-const CLAMD_TIMEOUT = 300000;
+const CLAMD_TIMEOUT = 5 * 60 * 1000;
 
 // Create Clients.
 const app = express();
@@ -117,6 +117,12 @@ async function handleGcsObject(req, res) {
           file.bucket);
       return;
     }
+    const chunkSize = parseInt(process.env.LARGE_FILE_CHUNK_SIZE);
+    if (!chunkSize) {
+      handleErrorResponse(res, 200, `large file chunk size not defined`);
+      return;
+    }
+    logger.info(`Large chunk size: ${chunkSize} bytes`);
 
     const gcsFile = storage.bucket(file.bucket).file(file.name);
     // File.exists() returns a FileExistsResponse, which is a list with a
@@ -136,12 +142,15 @@ async function handleGcsObject(req, res) {
       fileSize} bytes) scanning with clam ${clamdVersion}`);
     const startTime = Date.now();
 
-    // break up .zip archive by scanning each individual file separately to
-    // avoid the 4GB hard limit on clamd.
-    // const reader = new GcsFileRangeReader(gcsFile, GCS_FILE_READ_BUFFER_SIZE)
-    const rs = gcsFile.createReadStream();
-    const results = await scanGcsZipFile(
-        scanner, rs, fileSize, CLAMD_TIMEOUT);
+    // example entry: {result: 'OK', fileName: 'test_file.exe'}
+    let results;
+    try {
+      results = await scanGcsZipFile(
+          scanner, gcsFile, CLAMD_TIMEOUT, chunkSize);
+    } catch (err) {
+      logger.error(`Error scanning zip file: ${err}`);
+      throw err;
+    }
 
     const scanDuration = Date.now() - startTime;
 

--- a/cloudrun-malware-scanner/zip.js
+++ b/cloudrun-malware-scanner/zip.js
@@ -5,6 +5,7 @@ const clamd = require('clamdjs');
 const CLAMD_MAX_FILE_SIZE = 4 * 1024 * 1024 * 1024; // 4GB
 const SIZE_LIMIT_ERROR = 'INSTREAM size limit exceeded';
 const FALLBACK_RESOLVE_TIMEOUT = 10 * 1000; // 10 seconds
+const CHUNK_SCAN_OVERLAP_FACTOR = 0.25;
 
 /**
  * @param {*} scanner
@@ -148,9 +149,14 @@ function scanChunked(scanner, gcsFile, filePath, timeoutPerFile, chunkSize) {
   const processChunks = () => {
     try {
       const buffer = Buffer.concat(chunks);
-      // clear the accumulated data
-      bufferSize = 0;
-      chunks.length = 0;
+
+      // Remove (1 - overlap factor) * buffer size in bytes so we can scan
+      // overlapping ranges of data if malware signatures cross the chunk
+      // boundary.
+      while (bufferSize > chunkSize * CHUNK_SCAN_OVERLAP_FACTOR) {
+        bufferSize -= chunks.shift().length;
+      }
+
       const promise = scanner.scanBuffer(buffer, timeoutPerFile);
       promises.push(promise);
       promise.then((result) =>

--- a/cloudrun-malware-scanner/zip.js
+++ b/cloudrun-malware-scanner/zip.js
@@ -70,7 +70,7 @@ function scanGcsZipFile(scanner, gcsFile, timeoutPerFile, chunkSize) {
 
           // This is hacky but sometimes the 'finish' or 'close' event on the
           // outer stream is never emitted so we need to manually check if all
-          // per-file scans have completed. Wait 5 seconds and if the number
+          // per-file scans have completed. Wait a few seconds and if the number
           // of total and scanned files is unchanged, then we can assume all
           // files have started their scan and we can resolve when all scans
           // are completed. It's bad practice but OK to call `resolve` in

--- a/cloudrun-malware-scanner/zip.js
+++ b/cloudrun-malware-scanner/zip.js
@@ -1,32 +1,210 @@
 const {logger} = require('./logger.js');
 const unzip = require('unzip-stream');
+const clamd = require('clamdjs');
+
+const CLAMD_MAX_FILE_SIZE = 4 * 1024 * 1024 * 1024; // 4GB
+const SIZE_LIMIT_ERROR = 'INSTREAM size limit exceeded';
+const FALLBACK_RESOLVE_TIMEOUT = 10 * 1000; // 10 seconds
+
+/**
+ * @param {*} scanner
+ * @param {*} gcsFile
+ * @param {number} timeoutPerFile
+ * @param {number} chunkSize
+ * @return {Promise<Array<*>>} collection of clamd results
+ */
+function scanGcsZipFile(scanner, gcsFile, timeoutPerFile, chunkSize) {
+  const scanPromises = [];
+
+  let fileCount = 0;
+  let scannedCount = 0;
+
+  return new Promise((resolve, reject) => {
+    const readstream = gcsFile.createReadStream();
+
+    // First, try to scan zip archive fully and scan each individual file in
+    // full with clamd. If that fails, then break larger files up into smaller
+    // chunks to scan to avoid clam's hard 4GB limit.
+    // eslint-disable-next-line new-cap
+    readstream.pipe(unzip.Parse()).on('entry', async (entry) => {
+      if (entry.type === 'File') {
+        logger.info(`
+          Scanning ${entry.path} with size ${entry.size},
+          file ${++fileCount}/N
+        `);
+
+        // scan with chunks if size is defined and over 4GB
+        let promise;
+        if (entry.size && entry.size > CLAMD_MAX_FILE_SIZE) {
+          promise = scanChunked(
+              scanner, gcsFile, entry.path, timeoutPerFile, chunkSize);
+        } else {
+          promise = scanFully(scanner, entry, timeoutPerFile)
+              .catch((err) => {
+                // dispose of the original stream since we no longer need it
+                entry.autodrain();
+                if (err.message.includes(SIZE_LIMIT_ERROR)) {
+                  logger.warn(`
+                      Full scan failed for ${entry.path} due to size limit
+                      reached. Falling back to chunked scan.
+                  `);
+                  return scanChunked(
+                      scanner, gcsFile, entry.path, timeoutPerFile, chunkSize);
+                } else {
+                  throw err;
+                }
+              });
+        }
+        const promiseWithFilename = promise.then((result) => {
+          logger.info(
+              `Finished scanning ${entry.path} with result ${result}`,
+          );
+          logger.info(`Scanned ${++scannedCount} of ${fileCount}`);
+          return {result, fileName: entry.path};
+        });
+        scanPromises.push(promiseWithFilename);
+        promiseWithFilename.then(() => {
+          if (readstream.closed) {
+            return;
+          }
+
+          // This is hacky but sometimes the 'finish' or 'close' event on the
+          // outer stream is never emitted so we need to manually check if all
+          // per-file scans have completed. Wait 5 seconds and if the number
+          // of total and scanned files is unchanged, then we can assume all
+          // files have started their scan and we can resolve when all scans
+          // are completed. It's bad practice but OK to call `resolve` in
+          // multiple places but only the first call will succeed.
+          if (scannedCount === fileCount) {
+            logger.info(`
+              Scanned count equals file count. Checking if all files have been
+              added to the scan queue.
+            `);
+            const expectedTotalCount = fileCount;
+            setTimeout(() => {
+              if (fileCount === expectedTotalCount &&
+                scannedCount === fileCount) {
+                logger.info(`
+                  Finished processing ${scanPromises.length} entries.
+                `);
+                Promise.all(scanPromises)
+                    .then((results) => {
+                      logger.info(
+                          `Finished scanning ${results.length} results`);
+                      resolve(results);
+                    })
+                    .catch((err) => reject(err));
+              }
+            }, FALLBACK_RESOLVE_TIMEOUT);
+          }
+        });
+      } else {
+        // ignore directories
+        entry.autodrain();
+      }
+    }).on('close', () => {
+      logger.info(`
+        Finished processing ${scanPromises.length} entries...awaiting results.
+      `);
+      Promise.all(scanPromises)
+          .then((results) => {
+            logger.info(`Finished processing ${results.length} results`);
+            resolve(results);
+          })
+          .catch((err) => reject(err));
+    }).on('error', (err) => {
+      logger.error(`Error scanning zip file: ${err}`);
+      reject(err);
+    });
+  });
+}
 
 /**
  * @param {*} scanner
  * @param {*} readstream
- * @param {number} totalSize
- * @param {number} timeoutPerFile
- * @return {Promise<Array<string>>} collection of clamd results
+ * @param {*} timeoutPerFile
+ * @return {Promise<string>}
  */
-function scanGcsZipFile(scanner, readstream, totalSize, timeoutPerFile) {
-  const results = [];
+function scanFully(scanner, readstream, timeoutPerFile) {
+  return scanner.scanStream(readstream, timeoutPerFile);
+}
+
+/**
+ * @param {*} scanner
+ * @param {*} gcsFile
+ * @param {number} filePath
+ * @param {number} timeoutPerFile
+ * @param {number} chunkSize
+ * @return {Promise<string>} clamd result
+ */
+function scanChunked(scanner, gcsFile, filePath, timeoutPerFile, chunkSize) {
+  const rs = gcsFile.createReadStream();
+
+  const chunks = [];
+  let bufferSize = 0;
+  const promises = [];
+  let chunkCount = 0;
+
+  const processChunks = () => {
+    try {
+      const buffer = Buffer.concat(chunks);
+      // clear the accumulated data
+      bufferSize = 0;
+      chunks.length = 0;
+      const promise = scanner.scanBuffer(buffer, timeoutPerFile);
+      promises.push(promise);
+      promise.then((result) =>
+        logger.info(
+            `Finished scanning chunk ${++chunkCount} with result ${result}`,
+        ));
+    } catch (err) {
+      logger.error(`Error scanning chunk: ${err}`);
+      rs.destroy(err);
+    }
+  };
 
   return new Promise((resolve, reject) => {
     // eslint-disable-next-line new-cap
-    readstream.pipe(unzip.Parse()).on('entry', async (entry) => {
-      if (entry.type === 'File') {
-        logger.info(`Scanning ${entry.path} with size ${entry.size}`);
-        const result = await scanner.scanStream(entry, timeoutPerFile);
-        results.push({result, fileName: entry.path});
-        logger.info(`Finished scanning ${entry.path} with result ${result}`);
+    rs.pipe(unzip.Parse()).on('entry', (entry) => {
+      // Scan .zip again but look for specific file entry.
+      if (entry.path === filePath) {
+        // entry is a readstream
+        entry.on('data', async (chunk) => {
+          chunks.push(chunk);
+          bufferSize += chunk.length;
+
+          // drain the buffer + scan if we reached the max chunk size
+          if (bufferSize >= chunkSize) {
+            processChunks();
+          }
+        }).on('end', () => {
+          // process any remaining data
+          logger.info(
+              `Processing remaining buffer of size ${bufferSize} for
+              ${filePath}`,
+          );
+          processChunks();
+        });
       } else {
         entry.autodrain();
       }
     }).on('close', () => {
-      logger.info(`Finished scanning ${totalSize} bytes`);
-      resolve(results);
+      Promise.all(promises).then((results) => {
+        logger.info(
+            `Finished scanning ${promises.length} chunks for ${filePath}`,
+        );
+
+        // check if any results are not clean
+        const infectedResult = results.find((result) =>
+          !clamd.isCleanReply(result));
+        if (infectedResult) {
+          resolve(infectedResult);
+        } else {
+          resolve(results[0]);
+        }
+      }).catch((err) => reject(err));
     }).on('error', (err) => {
-      logger.error(`Error scanning zip file: ${err}`);
+      logger.error(`Error scanning zip file with chunks: ${err}`);
       reject(err);
     });
   });

--- a/cloudrun-malware-scanner/zip.js
+++ b/cloudrun-malware-scanner/zip.js
@@ -5,7 +5,7 @@ const clamd = require('clamdjs');
 const CLAMD_MAX_FILE_SIZE = 4 * 1024 * 1024 * 1024; // 4GB
 const SIZE_LIMIT_ERROR = 'INSTREAM size limit exceeded';
 const FALLBACK_RESOLVE_TIMEOUT = 10 * 1000; // 10 seconds
-const CHUNK_SCAN_OVERLAP_FACTOR = 0.25;
+const CHUNK_SCAN_OVERLAP_FACTOR = 0.1;
 
 /**
  * @param {*} scanner


### PR DESCRIPTION
* Wait for all inner per-entry scans to resolve before resolving with an overall .zip archive scan status
* If a full scan of a zip entry files, scan it in chunks instead

The logic here is convoluted for a few reasons:
* sometimes we know the size of a file inside a .zip archive, and sometimes we don't (NaN for some zip archives)
* sometimes the GCS file readstream passed to `unzip-stream` does not emit a 'finish' or 'close' event

clamav hard limit
https://github.com/Cisco-Talos/clamav/issues/809