### PR TITLE
Disable metrics reporting (for now)

### DIFF
--- a/cloudrun-malware-scanner/server.js
+++ b/cloudrun-malware-scanner/server.js
@@ -17,10 +17,10 @@
 const clamd = require('clamdjs');
 const express = require('express');
 const {Storage} = require('@google-cloud/storage');
-const {GoogleAuth} = require('google-auth-library');
+// const {GoogleAuth} = require('google-auth-library');
 const {logger} = require('./logger.js');
 const pkgJson = require('./package.json');
-const metrics = require('./metrics.js');
+// const metrics = require('./metrics.js');
 const util = require('node:util');
 const execFile = util.promisify(require('node:child_process').execFile);
 const {setTimeout} = require('timers/promises');
@@ -157,8 +157,8 @@ async function handleGcsObject(req, res) {
     if (results.every((result) => clamd.isCleanReply(result.result))) {
       logger.info(`Scan status for gs://${file.bucket}/${file.name}: CLEAN (${
         fileSize} bytes in ${scanDuration} ms)`);
-      metrics.writeScanClean(`gs://${file.bucket}`, fileSize,
-          scanDuration, clamdVersion);
+      // metrics.writeScanClean(`gs://${file.bucket}`, fileSize,
+      //     scanDuration, clamdVersion);
 
       // Respond to API client.
       res.json({status: 'clean', clam_version: clamdVersion});
@@ -168,8 +168,8 @@ async function handleGcsObject(req, res) {
       logger.warn(`Scan status for gs://${file.bucket}/${file.name}/
         ${infectedResult.fileName}: INFECTED ${infectedResult.result} 
         (${fileSize} bytes in ${scanDuration} ms)`);
-      metrics.writeScanInfected(`gs://${file.bucket}`, fileSize,
-          scanDuration, clamdVersion);
+      // metrics.writeScanInfected(`gs://${file.bucket}`, fileSize,
+      //     scanDuration, clamdVersion);
 
       // Respond to API client.
       res.json({
@@ -230,7 +230,7 @@ async function handleCvdUpdate(req, res) {
     res.json({
       status: 'CvdUpdateComplete',
       updated: newVersions.length > 0});
-    metrics.writeCvdMirrorUpdated(true, newVersions.length > 0);
+    // metrics.writeCvdMirrorUpdated(true, newVersions.length > 0);
   } catch (e) {
     logger.error(
         {err: e.message},
@@ -238,7 +238,7 @@ async function handleCvdUpdate(req, res) {
         e.message,
         e.code,
         e.stderr);
-    metrics.writeCvdMirrorUpdated(false, false);
+    // metrics.writeCvdMirrorUpdated(false, false);
     res.status(500).json({message: e.message, status: 'CvdUpdateError'});
   }
 }
@@ -280,7 +280,7 @@ function handleErrorResponse(res, statusCode, errorMessage,
     unscannedBucket = /** @type {string} */ null) {
   logger.error(`Error processing request: ${errorMessage}`);
   res.status(statusCode).json({message: errorMessage, status: 'error'});
-  metrics.writeScanFailed(unscannedBucket);
+  // metrics.writeScanFailed(unscannedBucket);
 }
 
 /**
@@ -369,12 +369,12 @@ async function waitForClamD() {
  * @async
  */
 async function run() {
-  let projectId = process.env.PROJECT_ID;
-  if (!projectId) {
-    // Metrics needs project ID, so get it from GoogleAuth
-    projectId = await (new GoogleAuth().getProjectId());
-  }
-  await metrics.init(projectId);
+  // let projectId = process.env.PROJECT_ID;
+  // if (!projectId) {
+  //   // Metrics needs project ID, so get it from GoogleAuth
+  //   projectId = await (new GoogleAuth().getProjectId());
+  // }
+  // await metrics.init(projectId);
   await verifyConfig();
   await waitForClamD();
 


### PR DESCRIPTION
Metrics reports are frequently failing even when a scan is successful. We aren't using these metrics reports yet so disabling for now and we can re-enable and debug in the future if it's helpful.

example:
```
GaxiosError: One or more TimeSeries could not be written: Field timeSeries[1].points[0].value had an invalid value: A point has an unrecognized value type. at Gaxios._request (/app/node_modules/@opencensus/exporter-stackdriver/node_modules/gaxios/build/src/gaxios.js:129:23) at process.processTicksAndRejections 
```