### PR TITLE
scan directly if file smaller than 4gb

### DIFF
--- a/cloudrun-malware-scanner/constants.js
+++ b/cloudrun-malware-scanner/constants.js
@@ -1,0 +1,5 @@
+const CLAMD_MAX_FILE_SIZE = 4 * 1024 * 1024 * 1024; // 4GB
+
+module.exports = {
+  CLAMD_MAX_FILE_SIZE,
+};

--- a/cloudrun-malware-scanner/server.js
+++ b/cloudrun-malware-scanner/server.js
@@ -25,6 +25,7 @@ const util = require('node:util');
 const execFile = util.promisify(require('node:child_process').execFile);
 const {setTimeout} = require('timers/promises');
 const scanGcsZipFile = require('./zip.js');
+const {CLAMD_MAX_FILE_SIZE} = require('./constants.js');
 
 const PORT = process.env.PORT || 8080;
 const CLAMD_HOST = '127.0.0.1';
@@ -145,8 +146,18 @@ async function handleGcsObject(req, res) {
     // example entry: {result: 'OK', fileName: 'test_file.exe'}
     let results;
     try {
-      results = await scanGcsZipFile(
-          scanner, gcsFile, CLAMD_TIMEOUT, chunkSize);
+      if (fileSize > CLAMD_MAX_FILE_SIZE) {
+        logger.info(`Scanning large file gs://${file.bucket}/${file.name} with chunk size ${chunkSize}`);
+        results = await scanGcsZipFile(
+            scanner, gcsFile, CLAMD_TIMEOUT, chunkSize);
+      } else {
+        // Pass file to clam directly if the entire bundle is under the per-file
+        // limit instead of having to read each file in the .zip separately
+        // and/or in chunks.
+        const rs = gcsFile.createReadStream();
+        const result = await scanner.scanStream(rs, CLAMD_TIMEOUT);
+        results = [{result: result, fileName: file.name}];
+      }
     } catch (err) {
       logger.error(`Error scanning zip file: ${err}`);
       throw err;

--- a/cloudrun-malware-scanner/zip.js
+++ b/cloudrun-malware-scanner/zip.js
@@ -1,8 +1,8 @@
 const {logger} = require('./logger.js');
 const unzip = require('unzip-stream');
 const clamd = require('clamdjs');
+const {CLAMD_MAX_FILE_SIZE} = require('./constants.js');
 
-const CLAMD_MAX_FILE_SIZE = 4 * 1024 * 1024 * 1024; // 4GB
 const SIZE_LIMIT_ERROR = 'INSTREAM size limit exceeded';
 const FALLBACK_RESOLVE_TIMEOUT = 10 * 1000; // 10 seconds
 const CHUNK_SCAN_OVERLAP_FACTOR = 0.1;


### PR DESCRIPTION
This is much faster than the per-file in .zip archive approach for smaller files under the 4GB clamav limit and does not depend on number of files or folders in the archive.